### PR TITLE
Fix the UTC datetime

### DIFF
--- a/gnomecontactsvcardimporter.py
+++ b/gnomecontactsvcardimporter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-import datetime
+from datetime import datetime, UTC
 import io
 import random
 import sqlite3
@@ -109,7 +109,7 @@ def insert_db_main(uid, file_as, nickname, full_name, given_name, family_name, v
     db_cursor = db_con.cursor()
 
     # Get a timestamp for the Rev column
-    rev_date_time = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    rev_date_time = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     # Insert the contact data
     db_cursor.execute('insert into folder_id (uid, Rev, file_as, nickname, full_name, given_name, family_name, vcard, is_list, list_show_addresses, wants_html, x509Cert, pgpCert) values (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0)', (uid, rev_date_time, file_as, nickname, full_name, given_name, family_name, vcard))


### PR DESCRIPTION
Hello !
Thank you for your project, it's help to provide my contacts to gnome-contacts

I have a little contribution for you
Currently, there is this warning with Python 3.12.11
```
>>> import datetime
>>> datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
<stdin>:1: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
'2025-10-20T16:48:48Z'
```

We can easily fix it like that:
```
>>> from datetime import datetime, UTC
>>> datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
'2025-10-20T16:49:02Z' 
```

Best see to you